### PR TITLE
Add support for exporting morph targets

### DIFF
--- a/UnityProject/Assets/Gltf/Editor/Exporter.Data.cs
+++ b/UnityProject/Assets/Gltf/Editor/Exporter.Data.cs
@@ -35,7 +35,7 @@ namespace Gltf.Serialization
             return index;
         }
 
-        private int ExportAccessor(int bufferViewIndex, Schema.AccessorComponentType componentType, int count, Schema.AccessorType type, IEnumerable<object> min, IEnumerable<object> max)
+        private int ExportAccessor(int bufferViewIndex, Schema.AccessorComponentType componentType, int count, Schema.AccessorType type, IEnumerable<object> min, IEnumerable<object> max, string name = null)
         {
             int index = this.accessors.Count;
 
@@ -48,12 +48,13 @@ namespace Gltf.Serialization
                 Type = type,
                 Min = min,
                 Max = max,
+                Name = name
             });
 
             return index;
         }
 
-        private int ExportData(Schema.AccessorType type, Schema.AccessorComponentType componentType, int componentSize, int count, IEnumerable<object> min, IEnumerable<object> max, int byteLength, Action<BinaryWriter> writeData)
+        private int ExportData(Schema.AccessorType type, Schema.AccessorComponentType componentType, int componentSize, int count, IEnumerable<object> min, IEnumerable<object> max, int byteLength, Action<BinaryWriter> writeData, string accessorName = null)
         {
             // The offset of the data must be aligned to a multiple of the component size.
             var position = checked((int)this.dataWriter.BaseStream.Position);
@@ -64,7 +65,7 @@ namespace Gltf.Serialization
             }
 
             var bufferViewIndex = this.ExportBufferView(0, alignedPosition, byteLength);
-            var accessorIndex = this.ExportAccessor(bufferViewIndex, componentType, count, type, min, max);
+            var accessorIndex = this.ExportAccessor(bufferViewIndex, componentType, count, type, min, max, accessorName);
 
             writeData(this.dataWriter);
 
@@ -97,7 +98,7 @@ namespace Gltf.Serialization
                 binaryWriter => values.ForEach(value => binaryWriter.Write(value)));
         }
 
-        private int ExportData(IEnumerable<Vector3> values)
+        private int ExportData(IEnumerable<Vector3> values, string accessorName = null)
         {
             return this.ExportData(
                 Schema.AccessorType.VEC3,
@@ -107,7 +108,8 @@ namespace Gltf.Serialization
                 new object[] { values.Select(value => value.x).Min(), values.Select(value => value.y).Min(), values.Select(value => value.z).Min() },
                 new object[] { values.Select(value => value.x).Max(), values.Select(value => value.y).Max(), values.Select(value => value.z).Max() },
                 sizeof(float) * 3 * values.Count(),
-                binaryWriter => values.ForEach(value => binaryWriter.Write(value)));
+                binaryWriter => values.ForEach(value => binaryWriter.Write(value)),
+                accessorName);
         }
 
         private int ExportData(IEnumerable<Vector4> values)

--- a/UnityProject/Assets/Gltf/Editor/Exporter.cs
+++ b/UnityProject/Assets/Gltf/Editor/Exporter.cs
@@ -626,7 +626,7 @@ namespace Gltf.Serialization
                 attributes.Add("POSITION", this.ExportData(InvertZ(unityMesh.vertices)));
 
                 // Blendshapes / MorphTargets
-                var targets = new List<Schema.Target>();
+                var targets = new List<IEnumerable<KeyValuePair<string, int>>>();
                 float[] weights = new float[unityMesh.blendShapeCount];
                 for (int blendShapeIndex = 0; blendShapeIndex < unityMesh.blendShapeCount; blendShapeIndex++)
                 {
@@ -655,11 +655,14 @@ namespace Gltf.Serialization
                     Vector3[] deltaTangents = new Vector3[unityMesh.vertexCount];
                     unityMesh.GetBlendShapeFrameVertices(blendShapeIndex, frameIndex, deltaVertices, deltaNormals, deltaTangents);
 
-                    targets.Add(new Schema.Target {
-                        Normal = this.ExportData(InvertZ(deltaNormals), name),
-                        Position = this.ExportData(InvertZ(deltaVertices), name),
-                        Tangent = this.ExportData(deltaTangents, name)
-                    });
+                    var target = new Dictionary<string, int>
+                    {
+                        { "NORMAL", this.ExportData(InvertZ(deltaNormals), name) },
+                        { "POSITION", this.ExportData(InvertZ(deltaVertices), name) },
+                        { "TANGENT", this.ExportData(deltaTangents, name) }
+                    };
+
+                    targets.Add(target);
                 }
 
                 index = this.meshes.Count;

--- a/UnityProject/Assets/Gltf/Editor/Schema.cs
+++ b/UnityProject/Assets/Gltf/Editor/Schema.cs
@@ -191,18 +191,28 @@ namespace Gltf.Schema
     }
 
     [Serializable]
+    public class Target
+    {
+        public int Position;
+        public int Normal;
+        public int Tangent;
+    }
+
+    [Serializable]
     public class MeshPrimitive : ChildOfRootProperty
     {
         public IEnumerable<KeyValuePair<string, int>> Attributes;
         public int Indices;
         public int Material;
         public PrimitiveMode Mode;
+        public IEnumerable<Target> Targets;
     }
 
     [Serializable]
     public class Mesh : ChildOfRootProperty
     {
         public IEnumerable<MeshPrimitive> Primitives;
+        public IEnumerable<float> Weights;
     }
 
     [Serializable]

--- a/UnityProject/Assets/Gltf/Editor/Schema.cs
+++ b/UnityProject/Assets/Gltf/Editor/Schema.cs
@@ -191,21 +191,13 @@ namespace Gltf.Schema
     }
 
     [Serializable]
-    public class Target
-    {
-        public int Position;
-        public int Normal;
-        public int Tangent;
-    }
-
-    [Serializable]
     public class MeshPrimitive : ChildOfRootProperty
     {
         public IEnumerable<KeyValuePair<string, int>> Attributes;
         public int Indices;
         public int Material;
         public PrimitiveMode Mode;
-        public IEnumerable<Target> Targets;
+        public IEnumerable<IEnumerable<KeyValuePair<string, int>>> Targets;
     }
 
     [Serializable]


### PR DESCRIPTION
* Exports all morph targets that are part of an `gameobject`'s mesh.

  > Unity gives access to Morph Targets (blendshapes) via the
  > `SkinnedMeshRenderer`.  We use that to gain access to the Mesh
  > that we export, and we loop through to get all blendshapes that
  > are on that Mesh.

  > We only export the final "frame" of the blendshape, as that is the
  > one that defines what the blendshape should look like at 100%
  > weight (given that glTF only supports a single frame of a blendshape).

* Added an explicit `Target` object to the schema.

  > This was necessary due to covariant issues that couldn't be resolved
  > with a .NET 2.5 project (possibly solveable with a 4.x project type,
  > but Unity wouldn't let me change the .NET target).  `Mesh` defines
  > `Targets` effectively as `List<Dictionary<string, int>>`, but we are
  > unable to convert that to `IEnumerable<IEnumerable<string, int>>` for
  > export.  Given that, it was solveable by just creating an explicit
  > type that defines the three properties.  The downside of this approach
  > is that these properties get camelCased out as opposed to being
  > UPPERCASE like the other `attributes`.

* Added the ability to set the name for an accessor.

  > I didn't add this to every possible `ExportData`...only the ones that
  > were in the codepath that morph targets use.  Given that there is no
  > way to store the name of a morph target anywhere else, we're storing
  > it as the name of the accessor for each attribute.